### PR TITLE
fix: use absolute path for .env loading (#14)

### DIFF
--- a/aigateway/config.py
+++ b/aigateway/config.py
@@ -2,8 +2,17 @@
 Configuration management for AI Gateway
 """
 
+import logging
+from pathlib import Path
 from pydantic_settings import BaseSettings
 from typing import Optional
+
+# Resolve .env path relative to this file's location so it loads correctly
+# regardless of the working directory when uvicorn is launched.
+_ENV_FILE = Path(__file__).parent.parent / ".env"
+
+if not _ENV_FILE.exists():
+    logging.warning(f"[config] .env file not found at {_ENV_FILE} — credentials will not be loaded")
 
 
 class Settings(BaseSettings):
@@ -40,7 +49,7 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
     
     class Config:
-        env_file = ".env"
+        env_file = str(_ENV_FILE)
         env_file_encoding = "utf-8"
 
 


### PR DESCRIPTION
## Summary

Fixes #14

Resolves `.env` path relative to `config.py`'s location using `pathlib.Path`, so credentials load correctly regardless of the working directory when uvicorn is launched.

## Problem

`env_file = ".env"` is resolved relative to the CWD at launch time. If uvicorn is started from any directory other than the repo root, `.env` silently fails to load and all integrations report as unconfigured.

This was observed in practice today — a Hub restart launched from a different directory caused GitHub auth to silently fail with no error in the response.

## Changes

- `aigateway/config.py`: resolve `_ENV_FILE` using `Path(__file__).parent.parent / ".env"` so it always points to the correct location
- Added startup warning log if `.env` is not found at the resolved path

## Testing

Verified by launching uvicorn from `/tmp` (wrong directory) and confirming GitHub credentials loaded and authenticated correctly (`sageopenclawbot`).