### PR TITLE
fix: add service manager detection and management guidance (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@
 
 ### Installation
 
+> **Already installed?** Check first before running any install commands:
+> ```bash
+> # macOS — is the Hub already a launchd service?
+> launchctl list | grep openclaw.hub
+>
+> # Linux — is the Hub already a systemd service?
+> systemctl --user status openclaw-hub
+>
+> # Either platform — is it simply running?
+> curl http://127.0.0.1:8080/health
+> ```
+> If the Hub is already running as a service, use `launchctl` (macOS) or `systemctl` (Linux) to manage it — **not** `pkill` or manual process commands. Killing the process directly will just cause the service manager to respawn it immediately.
+
 **Option 1: Auto-Start (Recommended for Production)**
 
 Install as a system service that starts automatically on boot:
@@ -74,6 +87,8 @@ cp .env.example .env
 ```
 
 **Option 2: Manual/Development**
+
+> ⚠️ **Only use this if you have NOT run `install-macos.sh` or `install-linux.sh`.** If you have, the Hub is already managed by a service manager — use Option 1's management commands instead.
 
 ```bash
 # Create virtual environment

--- a/aigateway/config.py
+++ b/aigateway/config.py
@@ -45,6 +45,10 @@ class Settings(BaseSettings):
     # Kie.ai (Video Generation - optional)
     kie_api_key: Optional[str] = None
     
+    # Service manager (set automatically by install scripts; do not edit manually)
+    # Values: "launchd" | "systemd" | "manual"
+    openclaw_service_manager: str = "manual"
+
     # Logging
     log_level: str = "INFO"
     

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -45,6 +45,7 @@ Restart=always
 RestartSec=10
 StandardOutput=append:$LOG_PATH
 StandardError=append:$LOG_PATH
+Environment=OPENCLAW_SERVICE_MANAGER=systemd
 
 [Install]
 WantedBy=default.target
@@ -65,21 +66,25 @@ if curl -s --max-time 2 http://127.0.0.1:8080/health > /dev/null 2>&1; then
     echo ""
     echo "✅ OpenClaw Hub installed successfully!"
     echo ""
-    echo "Service Status:"
-    systemctl --user status "$SERVICE_NAME" --no-pager -l
-    echo ""
     echo "📊 Dashboard: http://127.0.0.1:8080/docs"
     echo "📝 Logs:      journalctl --user -u $SERVICE_NAME -f"
     echo "             (or tail -f $LOG_PATH)"
     echo ""
-    echo "The Hub will now start automatically on system boot."
+    echo "The Hub will now start automatically on boot and restart if it crashes."
     echo ""
-    echo "Commands:"
-    echo "  Start:   systemctl --user start $SERVICE_NAME"
-    echo "  Stop:    systemctl --user stop $SERVICE_NAME"
-    echo "  Restart: systemctl --user restart $SERVICE_NAME"
-    echo "  Status:  systemctl --user status $SERVICE_NAME"
-    echo "  Disable: systemctl --user disable $SERVICE_NAME"
+    echo "┌─────────────────────────────────────────────────────────────────┐"
+    echo "│  ⚠️  SERVICE MANAGEMENT — IMPORTANT                             │"
+    echo "│                                                                 │"
+    echo "│  The Hub is managed by systemd. Use these commands:            │"
+    echo "│                                                                 │"
+    echo "│  Stop:    systemctl --user stop $SERVICE_NAME                  │"
+    echo "│  Start:   systemctl --user start $SERVICE_NAME                 │"
+    echo "│  Restart: systemctl --user restart $SERVICE_NAME               │"
+    echo "│  Status:  systemctl --user status $SERVICE_NAME                │"
+    echo "│                                                                 │"
+    echo "│  ❌ Do NOT use: pkill, kill, or nohup                          │"
+    echo "│     systemd will immediately respawn any killed process.       │"
+    echo "└─────────────────────────────────────────────────────────────────┘"
 else
     echo ""
     echo "⚠️  Service installed but health check failed."

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -66,6 +66,8 @@ cat > "$PLIST_PATH" << EOF
     <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin</string>
+        <key>OPENCLAW_SERVICE_MANAGER</key>
+        <string>launchd</string>
     </dict>
 </dict>
 </plist>
@@ -84,18 +86,23 @@ if curl -s --max-time 2 http://127.0.0.1:8080/health > /dev/null 2>&1; then
     echo ""
     echo "✅ OpenClaw Hub installed successfully!"
     echo ""
-    echo "Service Status:"
-    launchctl list | grep openclaw.hub || echo "  (service loaded)"
-    echo ""
     echo "📊 Dashboard: http://127.0.0.1:8080/docs"
     echo "📝 Logs:      tail -f $LOG_PATH"
     echo ""
-    echo "The Hub will now start automatically on system boot."
+    echo "The Hub will now start automatically on login and restart if it crashes."
     echo ""
-    echo "Commands:"
-    echo "  Start:   launchctl load ~/Library/LaunchAgents/$PLIST_NAME.plist"
-    echo "  Stop:    launchctl unload ~/Library/LaunchAgents/$PLIST_NAME.plist"
-    echo "  Restart: launchctl unload ~/Library/LaunchAgents/$PLIST_NAME.plist && launchctl load ~/Library/LaunchAgents/$PLIST_NAME.plist"
+    echo "┌─────────────────────────────────────────────────────────────────┐"
+    echo "│  ⚠️  SERVICE MANAGEMENT — IMPORTANT                             │"
+    echo "│                                                                 │"
+    echo "│  The Hub is managed by launchd. Use these commands:            │"
+    echo "│                                                                 │"
+    echo "│  Stop:    launchctl unload ~/Library/LaunchAgents/$PLIST_NAME.plist  │"
+    echo "│  Start:   launchctl load  ~/Library/LaunchAgents/$PLIST_NAME.plist   │"
+    echo "│  Status:  launchctl list | grep $PLIST_NAME                    │"
+    echo "│                                                                 │"
+    echo "│  ❌ Do NOT use: pkill, kill, or nohup                          │"
+    echo "│     launchd will immediately respawn any killed process.       │"
+    echo "└─────────────────────────────────────────────────────────────────┘"
 else
     echo ""
     echo "⚠️  Service installed but health check failed."


### PR DESCRIPTION
## Summary

Closes #18

Makes the Hub self-documenting about how it is managed at runtime, so agents and developers always know the correct commands to use.

## Changes

### `/health` endpoint
Now reports `managed_by` (launchd/systemd/manual) with correct stop/start commands for the detected service manager:
```json
{
  "status": "healthy",
  "service": {
    "managed_by": "launchd",
    "stop": "launchctl unload ~/Library/LaunchAgents/com.openclaw.hub.plist",
    "start": "launchctl load ~/Library/LaunchAgents/com.openclaw.hub.plist",
    "warning": "Do NOT use pkill — launchd will immediately respawn the process."
  }
}
```

### `install-macos.sh`
- Sets `OPENCLAW_SERVICE_MANAGER=launchd` in the plist `EnvironmentVariables`
- Adds a prominent warning box in the success output reminding users to use launchctl, not pkill

### `install-linux.sh`
- Sets `OPENCLAW_SERVICE_MANAGER=systemd` in the systemd unit `Environment`
- Adds matching warning box for systemctl

### `README.md`
- Adds "Already installed?" check block before installation options
- Adds warning before Manual/Development option

## Testing

Verified live: `/health` returns `managed_by: launchd` with correct commands after plist update.