### PR TITLE
fix: remove misleading RELOAD setting (#15)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@
 # Server
 HOST=127.0.0.1
 PORT=8080
-RELOAD=true
+# RELOAD=true  # Dev only: enables uvicorn hot-reload when running via `python -m aigateway.main`
+               # Has no effect when running via uvicorn CLI or a service manager (launchd/systemd)
 
 # Database
 DATABASE_URL=sqlite+aiosqlite:///./aigateway.db

--- a/aigateway/main.py
+++ b/aigateway/main.py
@@ -154,10 +154,13 @@ async def shutdown_event():
 
 if __name__ == "__main__":
     import uvicorn
+    # settings.reload is only respected here (direct run via `python -m aigateway.main`).
+    # When launched via uvicorn CLI or a service manager (launchd/systemd), pass --reload
+    # explicitly on the command line if needed. Do not enable reload in production.
     uvicorn.run(
-        "main:app",
-        host="127.0.0.1",  # localhost only for security
-        port=8080,
-        reload=True,  # Auto-reload during development
-        log_level="info"
+        "aigateway.main:app",
+        host=settings.host,
+        port=settings.port,
+        reload=settings.reload,
+        log_level=settings.log_level.lower()
     )


### PR DESCRIPTION
## Summary

Closes #15

`RELOAD=true` in `.env` had no effect because the Hub is launched via uvicorn CLI (or launchd/systemd), neither of which reads this setting from the config. It implied hot-reload was active when it was not.

## Changes

- **`.env.example`**: commented out `RELOAD` with a clear explanation — only applies when running via `python -m aigateway.main` (direct run), not uvicorn CLI or service managers
- **`aigateway/main.py`**: wired `settings.reload`, `settings.host`, `settings.port`, and `settings.log_level` into the `__main__` block so direct-run actually respects the config

Note: `.env` itself is gitignored. Remove `RELOAD=true` from your local `.env` if present.

## Testing

Hub restarted via launchctl and confirmed healthy — no regressions.