### PR TITLE
docs: add TweetClaw X/Twitter companion note

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ OpenClaw Hub is fully self-documenting!
   - `GET /v1/social/capabilities` — Instagram/social media details
   - `GET /v1/videos/capabilities` — Video generation details
 
+### X/Twitter Companion
+
+OpenClaw Hub's built-in social endpoints focus on Instagram posting and media upload. If an OpenClaw workspace also needs X/Twitter data or reviewed posting workflows, install [TweetClaw](https://github.com/Xquik-dev/tweetclaw) separately:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+Use Hub for model routing, workflows, MCP tools, GitHub operations, and Instagram publishing. Use TweetClaw for X/Twitter automation such as scrape tweets, search tweets, search tweet replies, follower export, user lookup, media upload, media download, direct messages, monitor tweets, webhooks, giveaway draws, and approval-reviewed post tweets or post tweet replies.
+
 ---
 
 ## Quick Start

--- a/docs/AI-AGENT-DISCOVERY.md
+++ b/docs/AI-AGENT-DISCOVERY.md
@@ -71,6 +71,16 @@ curl http://127.0.0.1:8080/v1/videos/capabilities
 → Shows Sora framework status and alternatives
 ```
 
+### Optional X/Twitter Discovery
+
+The Hub social capability endpoint covers Instagram. For X/Twitter workflows in the same OpenClaw workspace, install [TweetClaw](https://github.com/Xquik-dev/tweetclaw) separately:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+Then use Hub discovery for model routing, workflows, GitHub, MCP tools, and Instagram publishing, and use TweetClaw for X/Twitter automation such as scrape tweets, search tweets, search tweet replies, follower export, user lookup, media workflows, direct messages, monitor tweets, webhooks, giveaway draws, and approval-reviewed post tweets or post tweet replies.
+
 ### Step 4: Review OpenAPI Documentation (Optional)
 
 For detailed schemas:


### PR DESCRIPTION
## Description

Adds a short X/Twitter companion note to the README and AI Agent Discovery guide.

The Hub social endpoint currently documents Instagram posting and media upload. This keeps that scope intact and points OpenClaw users who also need X/Twitter workflows to TweetClaw as a separate OpenClaw plugin.

## Testing

- `git diff --check`
- Added-line dash scan
- Added-line sensitive-string scan
- Link sweep for README and AI Agent Discovery guide: 12 external links OK, 17 local URLs skipped, 1 existing example webhook URL skipped
- `npm view @xquik/tweetclaw version` returned `1.6.31`

No Python tests were run because this is a documentation-only change.
